### PR TITLE
[ENG-329] Add auto upgrade for content node

### DIFF
--- a/content-node/docker-compose/README.md
+++ b/content-node/docker-compose/README.md
@@ -17,7 +17,6 @@ The `setup.sh` script will prompt you for environment variables:
 * `SERVER_NAME` = your node's FQDN (details in [Setup Docs – Create the FQDN](https://docs.earthfast.com/node-operators/content-node-setup#create-the-fqdn-fully-qualified-domain-name), eg. `content0.us-east-2.testnet-sepolia.earthfast.operator.com`)
 * `NODE_ID` = the `NodeID` generated in [Setup Docs – Register your Node(s) onchain](https://docs.earthfast.com/node-operators/content-node-setup#register-your-node-s-onchain)
 * `SETUP_SSL` = if you have configured HTTPS/SSL externally, set this to `false`. Setting it to true will locally configure SSL with Let's Encrypt. Make sure the url from SERVER_NAME is correctly pointed to your server's IP address before enabling this option.
-* `CERTBOT_EMAIL` = If SETUP_SSL=true, this email will be used for SSL certificate renewal / management emails
 
 Confirm success by curling the `/statusz` endpoint:
 ```sh

--- a/content-node/docker-compose/README.md
+++ b/content-node/docker-compose/README.md
@@ -31,10 +31,14 @@ Confirm success by curling the `/statusz` endpoint:
 
 ## Updates
 
-To update your Content Node, pull the latest changes and restart:
+It's recommended that you enable auto upgrades so you get new version automatically
+```
+(crontab -l ; echo "0 4 * * * $(pwd)/auto-upgrade.sh")| crontab -
+```
+
+To manually update your Content Node, pull the latest changes and restart:
 ```sh
-git pull
-docker compose up -d
+sh update.sh <optional node-operator-tooling/ sha>
 ```
 
 ## Useful Docker Compose Commands
@@ -50,9 +54,7 @@ docker compose logs
 docker compose logs -f <path/to/docker-compose.yml>
 
 # Check logs of a specific container
-docker compose logs nginx
-docker compose logs certbot
-docker compose logs content-node
+docker compose logs <container-name>
 
 # Stop all containers
 docker compose down

--- a/content-node/docker-compose/README.md
+++ b/content-node/docker-compose/README.md
@@ -16,14 +16,11 @@ Clone this repository and run the setup script:
 The `setup.sh` script will prompt you for environment variables:
 * `SERVER_NAME` = your node's FQDN (details in [Setup Docs – Create the FQDN](https://docs.earthfast.com/node-operators/content-node-setup#create-the-fqdn-fully-qualified-domain-name), eg. `content0.us-east-2.testnet-sepolia.earthfast.operator.com`)
 * `NODE_ID` = the `NodeID` generated in [Setup Docs – Register your Node(s) onchain](https://docs.earthfast.com/node-operators/content-node-setup#register-your-node-s-onchain)
-* `SETUP_SSL` = if you have configured HTTPS/SSL externally, set this to `false`. Setting it to true will locally configure SSL with Let's Encrypt. Make sure the url from SERVER_NAME is correctly pointed to your server's IP address before enabling this option.
 
 Confirm success by curling the `/statusz` endpoint:
 ```sh
 # On the VM outside the container
-> docker exec -it docker-compose-nginx-1 /bin/bash -c "curl http://content-node:5000/statusz"
-# From outside the VM using the FQDN
-> curl <FQDN>:5000/statusz
+> curl localhost/statusz
 ```
 
 > Note: you may need to log out and log back in for your user to be able to run `docker compose`.
@@ -35,9 +32,9 @@ There's an option to enable auto upgrades for the content node, it's recommended
 ./setup.sh --auto-upgrade
 ```
 
-If you want to manually update your Content Node, run the following command:
+You can manually update your Content Node. Please monitor for new updates and run the following command:
 ```sh
-sh update.sh <optional node-operator-tooling/ sha>
+sh update.sh <optional sha>
 ```
 
 ## Useful Docker Compose Commands

--- a/content-node/docker-compose/README.md
+++ b/content-node/docker-compose/README.md
@@ -30,9 +30,9 @@ Confirm success by curling the `/statusz` endpoint:
 
 ## Updates
 
-The setup.sh script has an option to enable auto upgrading the content node, it's recommended you enable auto upgrades. You can turn this on by re-running `./setup.sh` or
+There's an option to enable auto upgrades for the content node, it's recommended you enable this so the latest features, bug fixes and updates will be deployed automatically. You can turn this on by running
 ```
-(crontab -l ; echo "* 4 * * * $(pwd)/auto-upgrade.sh")| crontab -
+./setup.sh --auto-upgrade
 ```
 
 If you want to manually update your Content Node, run the following command:

--- a/content-node/docker-compose/README.md
+++ b/content-node/docker-compose/README.md
@@ -30,12 +30,12 @@ Confirm success by curling the `/statusz` endpoint:
 
 ## Updates
 
-It's recommended that you enable auto upgrades so you get new version automatically
+The setup.sh script has an option to enable auto upgrading the content node, it's recommended you enable auto upgrades. You can turn this on by re-running `./setup.sh` or
 ```
-(crontab -l ; echo "0 4 * * * $(pwd)/auto-upgrade.sh")| crontab -
+(crontab -l ; echo "* 4 * * * $(pwd)/auto-upgrade.sh")| crontab -
 ```
 
-To manually update your Content Node, pull the latest changes and restart:
+If you want to manually update your Content Node, run the following command:
 ```sh
 sh update.sh <optional node-operator-tooling/ sha>
 ```

--- a/content-node/docker-compose/auto-upgrade.sh
+++ b/content-node/docker-compose/auto-upgrade.sh
@@ -24,7 +24,7 @@ fi
 
 # Check for git changes
 cd "$SCRIPT_DIR"
-BRANCH_NAME="dm-cn-autoupgrade" # TODO: switch back to main after testing
+BRANCH_NAME="main"
 git fetch origin
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/$BRANCH_NAME)

--- a/content-node/docker-compose/auto-upgrade.sh
+++ b/content-node/docker-compose/auto-upgrade.sh
@@ -23,16 +23,18 @@ if [ -f "$SCRIPT_DIR/.env" ]; then
 fi
 
 # Check for git changes
+cd "$SCRIPT_DIR"
+BRANCH_NAME="dm-cn-autoupgrade" # TODO: switch back to main after testing
 git fetch origin
 LOCAL=$(git rev-parse HEAD)
-REMOTE=$(git rev-parse origin/dm-cn-autoupgrade)
-# TODO: switch back to main after testing
+REMOTE=$(git rev-parse origin/$BRANCH_NAME)
+
 
 if [ "$LOCAL" != "$REMOTE" ]; then
   echo "Changes detected, updating repository..." >> "$LOG_FILE"
   
   # Update repository
-  git reset --hard origin/main
+  git reset --hard origin/$BRANCH_NAME
 
   # Restore .env
   if [ -f /tmp/.env.backup ]; then
@@ -42,7 +44,6 @@ if [ "$LOCAL" != "$REMOTE" ]; then
   fi
 
   # Docker operations
-  cd "$SCRIPT_DIR"
   COMPOSE_FILE=$(ls docker-compose.y*ml 2>/dev/null | head -n 1)
 
   if [ -z "$COMPOSE_FILE" ]; then

--- a/content-node/docker-compose/auto-upgrade.sh
+++ b/content-node/docker-compose/auto-upgrade.sh
@@ -5,6 +5,11 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 LOG_FILE="$SCRIPT_DIR/logs/git-auto-upgrade.log"
+mkdir -p "$SCRIPT_DIR/logs"
+if [ ! -f "$LOG_FILE" ]; then
+  touch "$LOG_FILE"
+fi
+
 echo "=== Starting auto-upgrade at $(date) ===" >> "$LOG_FILE"
 
 if [ ! -d "$SCRIPT_DIR" ]; then
@@ -18,12 +23,8 @@ if [ -f "$SCRIPT_DIR/.env" ]; then
 fi
 
 # Update repository
-if [ -d .git ]; then
-  git fetch origin
-  git reset --hard origin/main
-else
-  git clone "https://github.com/earthfast/node-operator-tooling" .
-fi
+git fetch origin
+git reset --hard origin/main
 
 # Restore .env
 if [ -f /tmp/.env.backup ]; then

--- a/content-node/docker-compose/auto-upgrade.sh
+++ b/content-node/docker-compose/auto-upgrade.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+# Get the directory where the script is located, regardless of where it's called from
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LOG_FILE="$SCRIPT_DIR/logs/git-auto-upgrade.log"
+echo "=== Starting auto-upgrade at $(date) ===" >> "$LOG_FILE"
+
+if [ ! -d "$SCRIPT_DIR" ]; then
+  echo "Error: No docker-compose directory found!" >> "$LOG_FILE"
+  exit 1
+fi
+
+# Backup .env if exists
+if [ -f "$SCRIPT_DIR/.env" ]; then
+  cp "$SCRIPT_DIR/.env" /tmp/.env.backup
+fi
+
+# Update repository
+if [ -d .git ]; then
+  git fetch origin
+  git reset --hard origin/main
+else
+  git clone "https://github.com/earthfast/node-operator-tooling" .
+fi
+
+# Restore .env
+if [ -f /tmp/.env.backup ]; then
+  mkdir -p "$SCRIPT_DIR"
+  cp /tmp/.env.backup "$SCRIPT_DIR/.env"
+  rm /tmp/.env.backup
+fi
+
+# Docker operations
+cd "$SCRIPT_DIR"
+COMPOSE_FILE=$(ls docker-compose.y*ml 2>/dev/null | head -n 1)
+
+if [ -z "$COMPOSE_FILE" ]; then
+  echo "Error: No docker-compose file found!" >> "$LOG_FILE"
+  exit 1
+fi
+
+docker compose -f "$COMPOSE_FILE" down --remove-orphans || true
+docker container prune -f
+docker network prune -f
+
+# Start services and don't fail if certbot has issues
+if ! docker compose -f "$COMPOSE_FILE" up -d; then
+  echo "Warning: Some services failed to start properly" >> "$LOG_FILE"
+  # Check if main services are running
+  if docker ps | grep -q "content-node"; then
+    echo "Main content-node service is running, continuing..." >> "$LOG_FILE"
+  else
+    echo "Critical service content-node is not running, exiting with error" >> "$LOG_FILE"
+    exit 1
+  fi
+fi
+
+echo "=== Completed auto-upgrade at $(date) ===" >> "$LOG_FILE"

--- a/content-node/docker-compose/auto-upgrade.sh
+++ b/content-node/docker-compose/auto-upgrade.sh
@@ -22,40 +22,51 @@ if [ -f "$SCRIPT_DIR/.env" ]; then
   cp "$SCRIPT_DIR/.env" /tmp/.env.backup
 fi
 
-# Update repository
+# Check for git changes
 git fetch origin
-git reset --hard origin/main
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/dm-cn-autoupgrade)
+# TODO: switch back to main after testing
 
-# Restore .env
-if [ -f /tmp/.env.backup ]; then
-  mkdir -p "$SCRIPT_DIR"
-  cp /tmp/.env.backup "$SCRIPT_DIR/.env"
-  rm /tmp/.env.backup
-fi
+if [ "$LOCAL" != "$REMOTE" ]; then
+  echo "Changes detected, updating repository..." >> "$LOG_FILE"
+  
+  # Update repository
+  git reset --hard origin/main
 
-# Docker operations
-cd "$SCRIPT_DIR"
-COMPOSE_FILE=$(ls docker-compose.y*ml 2>/dev/null | head -n 1)
+  # Restore .env
+  if [ -f /tmp/.env.backup ]; then
+    mkdir -p "$SCRIPT_DIR"
+    cp /tmp/.env.backup "$SCRIPT_DIR/.env"
+    rm /tmp/.env.backup
+  fi
 
-if [ -z "$COMPOSE_FILE" ]; then
-  echo "Error: No docker-compose file found!" >> "$LOG_FILE"
-  exit 1
-fi
+  # Docker operations
+  cd "$SCRIPT_DIR"
+  COMPOSE_FILE=$(ls docker-compose.y*ml 2>/dev/null | head -n 1)
 
-docker compose -f "$COMPOSE_FILE" down --remove-orphans || true
-docker container prune -f
-docker network prune -f
-
-# Start services and don't fail if certbot has issues
-if ! docker compose -f "$COMPOSE_FILE" up -d; then
-  echo "Warning: Some services failed to start properly" >> "$LOG_FILE"
-  # Check if main services are running
-  if docker ps | grep -q "content-node"; then
-    echo "Main content-node service is running, continuing..." >> "$LOG_FILE"
-  else
-    echo "Critical service content-node is not running, exiting with error" >> "$LOG_FILE"
+  if [ -z "$COMPOSE_FILE" ]; then
+    echo "Error: No docker-compose file found!" >> "$LOG_FILE"
     exit 1
   fi
+
+  docker compose -f "$COMPOSE_FILE" down --remove-orphans || true
+  docker container prune -f
+  docker network prune -f
+
+  # Start services and don't fail if certbot has issues
+  if ! docker compose -f "$COMPOSE_FILE" up -d; then
+    echo "Warning: Some services failed to start properly" >> "$LOG_FILE"
+    # Check if main services are running
+    if docker ps | grep -q "content-node"; then
+      echo "Main content-node service is running, continuing..." >> "$LOG_FILE"
+    else
+      echo "Critical service content-node is not running, exiting with error" >> "$LOG_FILE"
+      exit 1
+    fi
+  fi
+else
+  echo "No changes detected, skipping docker restart" >> "$LOG_FILE"
 fi
 
 echo "=== Completed auto-upgrade at $(date) ===" >> "$LOG_FILE"

--- a/content-node/docker-compose/docker-compose.yml
+++ b/content-node/docker-compose/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       }" > /etc/caddy/Caddyfile && caddy run --config /etc/caddy/Caddyfile'
     environment:
       - SERVER_NAME
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
     restart: unless-stopped
     depends_on:
       - content-node
@@ -40,23 +38,6 @@ services:
     volumes:
       - ${DATABASE_DIR}:/data/database
       - ${HOSTING_CACHE_DIR}:/data/hosting_cache
-    restart: unless-stopped
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
-    networks:
-      - content_network
-
-  watchtower:
-    profiles:
-      - autoupdate
-    image: containrrr/watchtower
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_INCLUDE_STOPPED=false
-      - WATCHTOWER_POLL_INTERVAL=60
-    command: --interval 60 --cleanup --include-restarting
     restart: unless-stopped
     networks:
       - content_network

--- a/content-node/docker-compose/setup.sh
+++ b/content-node/docker-compose/setup.sh
@@ -184,10 +184,6 @@ printf "${BLUE}Enter your node ID (e.g., 0xb10e2d52...)${NC}: "
 read -r NODE_ID
 NODE_ID=$(echo "$NODE_ID" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
 
-printf "${BLUE}Enter your email for SSL certificates${NC}: "
-read -r CERTBOT_EMAIL
-CERTBOT_EMAIL=$(echo "$CERTBOT_EMAIL" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
-
 # Verify FQDN points to correct IP
 log_info "Verifying FQDN..."
 if ! verify_fqdn "$SERVER_NAME"; then
@@ -228,7 +224,6 @@ log_info "Creating .env file..."
 cat >.env <<EOF
 SERVER_NAME=$SERVER_NAME
 NODE_ID=$NODE_ID
-CERTBOT_EMAIL=$CERTBOT_EMAIL
 RPC_URL=https://eth-sepolia.g.alchemy.com/v2/5opzBW-mCA1jMP0Z5mC1NIDJn_O3edas
 CONTRACT_ADDRESS=$CONTRACT_ADDRESS
 HOSTING_CACHE_DIR=/hosting_cache

--- a/content-node/docker-compose/setup.sh
+++ b/content-node/docker-compose/setup.sh
@@ -94,15 +94,31 @@ verify_fqdn() {
     fi
 }
 
+# Check ports
+check_ports() {
+    local ports=("80" "443")
+    local success=true
+    for port in "${ports[@]}"; do
+        if netstat -tuln | grep -q ":$port "; then
+            log_error "Port $port is already in use"
+            success=false
+        else
+            log_success "Port $port is available"
+        fi
+    done
+
+    # TODO: Check if ports are accessible from outside
+
+    return $([[ "$success" == "true" ]] && echo 0 || echo 1)
+}
+
 # Parse command line arguments
 ENVIRONMENT="testnet"
-AUTO_UPGRADE="false"
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
     --help | -h) usage ;;
     --staging) ENVIRONMENT="staging" ;;
-    --auto-upgrade) AUTO_UPGRADE="true" ;;
     *)
         log_error "Unknown parameter: $1"
         usage
@@ -112,9 +128,6 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 log_info "Starting setup process..."
-if [ "$AUTO_UPGRADE" = "true" ]; then
-    log_info "Auto-upgrade is enabled"
-fi
 
 # Check and install Docker if needed
 if ! command -v docker &>/dev/null; then
@@ -141,6 +154,7 @@ fi
 CONTRACT_ADDRESS=$([ "$ENVIRONMENT" = "staging" ] && echo "0x69e4aa095489E8613B4C4d396DD916e66D66aE23" || echo "0xb1c5F9914648403cb32a4f83B0fb946E5f7702CC")
 log_info "Using contract address: $CONTRACT_ADDRESS"
 
+ENV_SETUP="true"
 # Check if .env file exists and handle setup process
 if [ -f ".env" ]; then
     log_info "Current .env file contents:"
@@ -151,76 +165,49 @@ if [ -f ".env" ]; then
     log_warning "An .env file already exists!"
     read -p "Would you like to go through the .env setup process again? (y/n): " setup_again
 
-    if [[ ! $setup_again =~ ^[Yy]$ ]]; then
-        log_info "Keeping existing .env file."
-        echo
-        if [ "$AUTO_UPGRADE" = "true" ]; then
-            log_info "To start the content node with auto-upgrade, use: ${GREEN}docker compose --profile autoupdate up -d${NC}"
-        else
-            log_info "To start the content node, use: ${GREEN}docker compose up -d${NC}"
-        fi
-        # Remind to restart if docker group was added
-        if groups $USER | grep -q "\bdocker\b"; then
-            log_warning "Please log out and log back in for Docker group changes to take effect."
-        fi
-        exit 0
+    if [[ $setup_again =~ ^[Yy]$ ]]; then
+        # Backup existing .env file
+        backup_file=".env.backup.$(date +%Y%m%d_%H%M%S)"
+        mv .env "$backup_file"
+        log_info "Existing .env file backed up to $backup_file"
+        log_info "Proceeding with new .env setup..."
+    else
+        ENV_SETUP="false"
     fi
-
-    # Backup existing .env file
-    backup_file=".env.backup.$(date +%Y%m%d_%H%M%S)"
-    mv .env "$backup_file"
-    log_info "Existing .env file backed up to $backup_file"
-    log_info "Proceeding with new .env setup..."
 fi
 
-log_info "Please provide the following information:"
-printf "\n"
+if [ "$ENV_SETUP" = "true" ]; then
+    log_info "Please provide the following information:"
+    printf "\n"
 
-printf "${BLUE}Enter your server name (e.g., content-1.us-east-1.sepolia.earthfastnodes.com)${NC}: "
-read -r SERVER_NAME
-SERVER_NAME=$(echo "$SERVER_NAME" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+    printf "${BLUE}Enter your server name (e.g., content-1.us-east-1.sepolia.earthfastnodes.com)${NC}: "
+    read -r SERVER_NAME
+    SERVER_NAME=$(echo "$SERVER_NAME" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
 
-printf "${BLUE}Enter your node ID (e.g., 0xb10e2d52...)${NC}: "
-read -r NODE_ID
-NODE_ID=$(echo "$NODE_ID" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+    printf "${BLUE}Enter your node ID (e.g., 0xb10e2d52...)${NC}: "
+    read -r NODE_ID
+    NODE_ID=$(echo "$NODE_ID" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
 
 # Verify FQDN points to correct IP
-log_info "Verifying FQDN..."
-if ! verify_fqdn "$SERVER_NAME"; then
-    log_error "FQDN verification failed. Exiting..."
-    exit 1
-fi
-
-# Check ports
-check_ports() {
-    local ports=("80" "443")
-    local success=true
-    for port in "${ports[@]}"; do
-        if netstat -tuln | grep -q ":$port "; then
-            log_error "Port $port is already in use"
-            success=false
-        else
-            log_success "Port $port is available"
-        fi
-    done
-
-    # TODO: Check if ports are accessible from outside
-
-    return $([[ "$success" == "true" ]] && echo 0 || echo 1)
-}
-
-log_info "Checking ports..."
-if ! check_ports; then
-    log_error "Port check failed. Please ensure ports 80 and 443 are open and available."
-    read -p "Continue anyway? (y/n): " continue
-    if [[ ! $continue =~ ^[Yy]$ ]]; then
-        log_error "Setup cancelled due to port verification failure."
+    log_info "Verifying FQDN..."
+    if ! verify_fqdn "$SERVER_NAME"; then
+        log_error "FQDN verification failed. Exiting..."
         exit 1
     fi
-fi
 
-# Create .env file
-log_info "Creating .env file..."
+
+    log_info "Checking ports..."
+    if ! check_ports; then
+        log_error "Port check failed. Please ensure ports 80 and 443 are open and available."
+        read -p "Continue anyway? (y/n): " continue
+        if [[ ! $continue =~ ^[Yy]$ ]]; then
+            log_error "Setup cancelled due to port verification failure."
+            exit 1
+        fi
+    fi
+
+    # Create .env file
+    log_info "Creating .env file..."
 cat >.env <<EOF
 SERVER_NAME=$SERVER_NAME
 NODE_ID=$NODE_ID
@@ -228,20 +215,23 @@ RPC_URL=https://eth-sepolia.g.alchemy.com/v2/5opzBW-mCA1jMP0Z5mC1NIDJn_O3edas
 CONTRACT_ADDRESS=$CONTRACT_ADDRESS
 HOSTING_CACHE_DIR=/hosting_cache
 DATABASE_DIR=/db_data
-AUTO_UPGRADE=$AUTO_UPGRADE
 EOF
 
-log_success ".env file created successfully!"
-echo
-if [ "$AUTO_UPGRADE" = "true" ]; then
-    log_info "Auto-upgrade is enabled. Watchtower will:"
-    log_info "- Monitor and update Docker containers"
-    log_info "- Monitor and pull Git repository updates"
-    log_info "- Automatically restart services when updates are detected"
-    log_info "To start the content node with auto-upgrade, use: ${GREEN}docker compose --profile autoupdate up -d${NC}"
-else
-    log_info "To start the content node, use: ${GREEN}docker compose up -d${NC}"
+    log_success ".env file created successfully!"
 fi
+
+echo
+# ask if auto-upgrade is wanted
+read -p "Would you like to enable auto-upgrade? (y/n): " auto_upgrade 
+if [[ $auto_upgrade =~ ^[Yy]$ ]]; then
+    # will check at the top of every hour between minutes 0 and 10
+    if ! crontab -l | grep -q "$(pwd)/auto-upgrade.sh"; then
+        (crontab -l ; echo "$((RANDOM % 10)) * * * * $(pwd)/auto-upgrade.sh")| crontab -
+    fi
+    log_success "Auto-upgrade set up successfully!"
+fi
+
+log_info "To start the content node, use: ${GREEN}docker compose up -d${NC}"
 
 # Remind to restart if docker group was added
 if groups $USER | grep -q "\bdocker\b"; then


### PR DESCRIPTION
Few quality of life changes for node operators
1. Remove certbot in favor of caddy auto https
2. Replace watchtower with auto update script trigged via cron
3. Add cron auto upgrade to setup script

This has been tested by provisioning a new EC2 instance and calling setup and running the new docker compose, installing the auto update cron and making sure the updates happen

The only outstanding question is how do we roll this out to existing nodes / should we roll out (there's a good chance it continues to work as is)